### PR TITLE
Add docker hub ci action

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,33 @@
+name: push
+
+on: push
+
+jobs:
+  push:
+    name: Push to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: your-username/your-image-name
+          tags: |
+            type=ref,prefix=dev-,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}
+            type=semver,pattern={{major}}.{{minor}}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Be the change et al if Windows is your main and you wanna [raise a PR](CONTRIBUT
   * [Setup](#setup)
   * [Usage](#usage)
     * [Mac and Linux users](#mac-and-linux-users)
+  * [Pushing to Docker Hub with CI](#pushing-to-docker-hub-with-ci)
   * [TODO](#todo)
 
 ## Setup
@@ -36,6 +37,19 @@ Be the change et al if Windows is your main and you wanna [raise a PR](CONTRIBUT
 ## Usage
 ### Mac and Linux users
 Development environments and tooling are first-class citizens on macOS and *nix. For Windows faithfuls, please setup [WSL](markdown/wsl.md).
+
+## Pushing to Docker Hub with CI
+Docker Hub is a cloud-based repository in which Docker users and partners create, test, store and distribute container images. Docker images are pushed to Docker Hub through the docker push command. A single Docker Hub repository can hold many Docker images (stored as tags).
+
+Automated CI is implemented via GitHub Actions to build and push this repository's image to Docker Hub in `/.github/workflows/push.yml`.
+
+### What you need to modify in this file
+
+* Look for `images: your-username/your-image-name` and change to your respective Docker Hub username and image name.
+* Add repository secrets for `DOCKERHUB_TOKEN` and `DOCKERHUB_USERNAME` on this repository on GitHub.
+  * Here are the [instructions to create a token](https://docs.docker.com/docker-hub/access-tokens/#create-an-access-token).
+
+Here are the [instructions to disable this action](https://docs.github.com/en/actions/managing-workflow-runs/disabling-and-enabling-a-workflow) if you don't want this feature.
 
 ## TODO
 * [Open Issues](https://github.com/pythoninthegrass/python_template/issues)


### PR DESCRIPTION
Addresses a portion of #11. I created a `push.yml` file that will automate building and pushing this repo's Docker image to Docker Hub. Instructions are included in the README on what needs modified in the file for an individual's respective projects.

**Note**: you will want to disable this workflow for your public template because it will fail. 🫶🏼